### PR TITLE
Removes non-existent import statement so that the code builds.

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -15,7 +15,6 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import frc.robot.autoRoutines.*;
 import frc.robot.commands.*;
 import frc.robot.subsystems.*;
 


### PR DESCRIPTION
I've  found that I run `./gradlew build` in the terminal to ensure that the code builds (whether or not it actually works is another thing entirely).

When I did this on the Crescendo-main branch, the build failed cuz of this line so I removed it so that it now builds!