### PR TITLE
Updates projectYear so the 2024 VS stops telling us this code is not …

### DIFF
--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -1,6 +1,6 @@
 {
     "enableCppIntellisense": false,
     "currentLanguage": "java",
-    "projectYear": "2024",
+    "projectYear": "2024beta",
     "teamNumber": 1799
 }


### PR DESCRIPTION
When I open this code using the 2024 WPILib VS Code, I'd get a warning that the code is not compatible with 2024 WPILib VS Code when it actually is. This change prevents that annoying, useless warning from showing up.